### PR TITLE
fix: wrap all of a statement in hover element

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -10,7 +10,8 @@
 /* Adelfa hover popups */
 .twoslash-hover {
   position: relative;
-  border-bottom: 1px dotted currentColor;
+  text-decoration: underline dotted currentColor;
+  text-underline-offset: 3px;
   cursor: pointer;
 }
 
@@ -51,4 +52,3 @@
   height: 0;
   pointer-events: none;
 }
-

--- a/transformers/adelfa-renderer.mjs
+++ b/transformers/adelfa-renderer.mjs
@@ -16,18 +16,21 @@ export function rendererRich(options = {}) {
   const { hast } = options;
 
   return {
-    nodeStaticInfo(info, node) {
+    nodeStaticInfo(info, node, options = {}) {
       if (!info.output?.length) return node;
+
+      const properties = {
+        class: "twoslash-hover",
+        "data-popup-input": info.input,
+        "data-popup-output": info.output,
+      };
+      if (options.style) properties.style = options.style;
 
       return extend(hast?.hoverToken, {
         type: "element",
         tagName: "span",
-        properties: {
-          class: "twoslash-hover",
-          "data-popup-input": info.input,
-          "data-popup-output": info.output,
-        },
-        children: [node],
+        properties,
+        children: Array.isArray(node) ? node : [node],
       });
     },
   };


### PR DESCRIPTION
We had done a hack to get hover popups before which meant that only the `.` would recognize hover / click events. This change makes it so that the entire statement has such recognition. However, there is still a limitation that multi-line statements have to be the only statements on their lines. This is because shiki wraps lines in a span so once we become a multi-line statement we have to wrap the entire line. There is probably a good workaround but it's not immediately evident to my.